### PR TITLE
Implement Sightings Mapping and fix indicators

### DIFF
--- a/api/enrich.py
+++ b/api/enrich.py
@@ -144,57 +144,149 @@ def extract_judgement(output):
     return doc
 
 
-def extract_indicators(output):
+def extract_indicators(output, unique_ids):
     docs = []
+
+    if output.get('riskfactors'):
+        for riskfactor in output['riskfactors']:
+            if riskfactor['rfid'] not in unique_ids['riskfactors'].keys():
+                generated_id = f'transient:{uuid4()}'
+                unique_ids['riskfactors'][riskfactor['rfid']] = generated_id
+                doc = {
+                    'id': generated_id,
+                    'valid_time': get_valid_time(output),
+                    'short_description': riskfactor['description'],
+                    'producer': 'Pulsedive',
+                    **current_app.config['CTIM_INDICATOR_DEFAULTS']
+                }
+                docs.append(doc)
+
+    if output.get('threats'):
+        for threat in output['threats']:
+            if threat['tid'] not in unique_ids['threats'].keys():
+                generated_id = f'transient:{uuid4()}'
+                unique_ids['threats'][threat['tid']] = generated_id
+                score = output['risk']
+
+                type_mapping = \
+                    current_app.config["PULSEDIVE_API_THREAT_TYPES"][score]
+
+                start_time = datetime.strptime(threat['stamp_linked'],
+                                               '%Y-%m-%d %H:%M:%S')
+
+                doc = {
+                    'id': generated_id,
+                    'short_description': threat['name'],
+                    'producer': 'Pulsedive',
+                    'valid_time': {'start_time': start_time.isoformat() + 'Z'},
+                    'tags': [threat['category']],
+                    'severity': type_mapping['severity'],
+                    'source_uri': current_app.config['UI_URL'].format(
+                        query=f"threat/?tid={threat['tid']}"),
+                    **current_app.config['CTIM_INDICATOR_DEFAULTS']
+                }
+                docs.append(doc)
+
+    if output.get('feeds'):
+        for feed in output['feeds']:
+            if feed['fid'] not in unique_ids['feeds'].keys():
+                generated_id = f'transient:{uuid4()}'
+                unique_ids['feeds'][feed['fid']] = generated_id
+                start_time = datetime.strptime(feed['stamp_linked'],
+                                               '%Y-%m-%d %H:%M:%S')
+                doc = {
+                    'id': generated_id,
+                    'valid_time': {'start_time': start_time.isoformat() + 'Z'},
+                    'short_description': feed['name'],
+                    'producer': feed['organization'],
+                    'tags': [feed['category']],
+                    'source_uri': current_app.config['UI_URL'].format(
+                        query=f"feed/?fid={feed['fid']}"),
+                    **current_app.config['CTIM_INDICATOR_DEFAULTS']
+                }
+                docs.append(doc)
+
+    return docs
+
+
+def extract_sightings(output):
+    docs = []
+
+    start_time = datetime.strptime(output['stamp_seen'],
+                                   '%Y-%m-%d %H:%M:%S')
+    observable = {
+        'value': output['indicator'],
+        'type': output['type']
+    }
+
+    score = output['risk']
+
+    if output['retired'] and score == 'none':
+        score = 'retired'
+
+    type_mapping = \
+        current_app.config["PULSEDIVE_API_THREAT_TYPES"][score]
+
+    related = output['properties'].get('dns', {}).get('A')
+    relations = {
+        'relations':
+            [{
+                'origin': 'Pulsedive Enrichment Module',
+                'related': {'type': 'ip', 'value': related},
+                'relation': 'Resolved_To',
+                'source': observable,
+            }]
+        }
 
     if output.get('riskfactors'):
         for riskfactor in output['riskfactors']:
             doc = {
                 'id': f'transient:{uuid4()}',
-                'valid_time': get_valid_time(output),
+                'count': len(output['riskfactors']),
+                'observables': [observable],
+                'observed_time': {'start_time': start_time.isoformat() + 'Z'},
                 'short_description': riskfactor['description'],
-                'producer': 'Pulsedive',
-                **current_app.config['CTIM_INDICATOR_DEFAULTS']
+                'severity': type_mapping['severity'],
+                'source_uri': current_app.config['UI_URL'].format(
+                    query=f"indicator/?iid={output['iid']}"),
+                **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
+            if related:
+                doc.update(relations)
             docs.append(doc)
 
     if output.get('threats'):
         for threat in output['threats']:
-            score = output['risk']
-
-            type_mapping = \
-                current_app.config["PULSEDIVE_API_THREAT_TYPES"][score]
-
-            start_time = datetime.strptime(threat['stamp_linked'],
-                                           '%Y-%m-%d %H:%M:%S')
-
             doc = {
                 'id': f'transient:{uuid4()}',
+                'count': len(output['threats']),
+                'observables': [observable],
                 'short_description': threat['name'],
-                'producer': 'Pulsedive',
-                'valid_time': {'start_time': start_time.isoformat() + 'Z'},
-                'tags': [threat['category']],
+                'observed_time': {'start_time': start_time.isoformat() + 'Z'},
                 'severity': type_mapping['severity'],
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"threat/?tid={threat['tid']}"),
-                **current_app.config['CTIM_INDICATOR_DEFAULTS']
+                **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
+            if related:
+                doc.update(relations)
             docs.append(doc)
 
     if output.get('feeds'):
+
         for feed in output['feeds']:
-            start_time = datetime.strptime(feed['stamp_linked'],
-                                           '%Y-%m-%d %H:%M:%S')
             doc = {
                 'id': f'transient:{uuid4()}',
-                'valid_time': {'start_time': start_time.isoformat() + 'Z'},
+                'count': len(output['feeds']),
+                'observables': [observable],
+                'observed_time': {'start_time': start_time.isoformat() + 'Z'},
                 'short_description': feed['name'],
-                'producer': feed['organization'],
-                'tags': [feed['category']],
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"feed/?fid={feed['fid']}"),
-                **current_app.config['CTIM_INDICATOR_DEFAULTS']
+                **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
+            if related:
+                doc.update(relations)
             docs.append(doc)
 
     return docs
@@ -224,10 +316,13 @@ def observe_observables():
     verdicts = []
     judgements = []
     indicators = []
+    sightings = []
+    unique_ids = {'riskfactors': {}, 'threats': {}, 'feeds': {}}
     for output in pulsedive_outputs:
         verdicts.append(extract_verdict(output))
         judgements.append(extract_judgement(output))
-        indicators += extract_indicators(output)
+        indicators += extract_indicators(output, unique_ids)
+        sightings += extract_sightings(output)
     relay_output = {}
 
     if judgements:
@@ -236,6 +331,8 @@ def observe_observables():
         relay_output['verdicts'] = format_docs(verdicts)
     if indicators:
         relay_output['indicators'] = format_docs(indicators)
+    if sightings:
+        relay_output['sightings'] = format_docs(sightings)
 
     return jsonify_data(relay_output)
 

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -212,8 +212,6 @@ def extract_indicators(output, unique_ids):
 def extract_sightings(output):
     docs = []
 
-    start_time = datetime.strptime(output['stamp_seen'],
-                                   '%Y-%m-%d %H:%M:%S')
     observable = {
         'value': output['indicator'],
         'type': output['type']
@@ -237,6 +235,10 @@ def extract_sightings(output):
 
     if output.get('riskfactors'):
         for riskfactor in output['riskfactors']:
+
+            start_time = datetime.strptime(output['stamp_seen'],
+                                           '%Y-%m-%d %H:%M:%S')
+
             doc = {
                 'id': f'transient:{uuid4()}',
                 'count': len(output['riskfactors']),
@@ -254,6 +256,10 @@ def extract_sightings(output):
 
     if output.get('threats'):
         for threat in output['threats']:
+
+            start_time = datetime.strptime(threat['stamp_linked'],
+                                           '%Y-%m-%d %H:%M:%S')
+
             doc = {
                 'id': f'transient:{uuid4()}',
                 'count': len(output['threats']),
@@ -272,6 +278,9 @@ def extract_sightings(output):
     if output.get('feeds'):
 
         for feed in output['feeds']:
+
+            start_time = datetime.strptime(feed['stamp_linked'],
+                                           '%Y-%m-%d %H:%M:%S')
             doc = {
                 'id': f'transient:{uuid4()}',
                 'count': len(output['feeds']),

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -229,14 +229,11 @@ def extract_sightings(output):
 
     related = output['properties'].get('dns', {}).get('A')
     relations = {
-        'relations':
-            [{
                 'origin': 'Pulsedive Enrichment Module',
                 'related': {'type': 'ip', 'value': related},
                 'relation': 'Resolved_To',
                 'source': observable,
-            }]
-        }
+            }
 
     if output.get('riskfactors'):
         for riskfactor in output['riskfactors']:
@@ -245,14 +242,14 @@ def extract_sightings(output):
                 'count': len(output['riskfactors']),
                 'observables': [observable],
                 'observed_time': {'start_time': start_time.isoformat() + 'Z'},
-                'short_description': riskfactor['description'],
+                'description': riskfactor['description'],
                 'severity': type_mapping['severity'],
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"indicator/?iid={output['iid']}"),
                 **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
             if related:
-                doc.update(relations)
+                doc['relations'] = [relations]
             docs.append(doc)
 
     if output.get('threats'):
@@ -261,7 +258,7 @@ def extract_sightings(output):
                 'id': f'transient:{uuid4()}',
                 'count': len(output['threats']),
                 'observables': [observable],
-                'short_description': threat['name'],
+                'description': threat['name'],
                 'observed_time': {'start_time': start_time.isoformat() + 'Z'},
                 'severity': type_mapping['severity'],
                 'source_uri': current_app.config['UI_URL'].format(
@@ -269,7 +266,7 @@ def extract_sightings(output):
                 **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
             if related:
-                doc.update(relations)
+                doc['relations'] = [relations]
             docs.append(doc)
 
     if output.get('feeds'):
@@ -280,13 +277,13 @@ def extract_sightings(output):
                 'count': len(output['feeds']),
                 'observables': [observable],
                 'observed_time': {'start_time': start_time.isoformat() + 'Z'},
-                'short_description': feed['name'],
+                'description': feed['name'],
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"feed/?fid={feed['fid']}"),
                 **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
             if related:
-                doc.update(relations)
+                doc['relations'] = [relations]
             docs.append(doc)
 
     return docs

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -76,7 +76,7 @@ def get_pulsedive_output(observables):
 
 
 def time_to_ctr_format(time):
-    return {'start_time': time.isoformat() + 'Z'}
+    return time.isoformat() + 'Z'
 
 
 def get_valid_time(output):
@@ -90,8 +90,8 @@ def get_valid_time(output):
         end_time = start_time + STORAGE_PERIOD
 
     valid_time = {
-        'start_time': start_time.isoformat() + 'Z',
-        'end_time': end_time.isoformat() + 'Z',
+        'start_time': time_to_ctr_format(start_time),
+        'end_time': time_to_ctr_format(end_time),
                 }
 
     return valid_time
@@ -189,7 +189,9 @@ def extract_indicators(output, unique_ids):
                     'id': generated_id,
                     'short_description': threat['name'],
                     'producer': 'Pulsedive',
-                    'valid_time': time_to_ctr_format(start_time),
+                    'valid_time': {
+                        'start_time': time_to_ctr_format(start_time)
+                    },
                     'tags': [threat['category']],
                     'severity': type_mapping['severity'],
                     'source_uri': current_app.config['UI_URL'].format(
@@ -209,7 +211,9 @@ def extract_indicators(output, unique_ids):
                                                '%Y-%m-%d %H:%M:%S')
                 doc = {
                     'id': generated_id,
-                    'valid_time': time_to_ctr_format(start_time),
+                    'valid_time': {
+                        'start_time': time_to_ctr_format(start_time)
+                    },
                     'short_description': feed['name'],
                     'producer': feed['organization'],
                     'tags': [feed['category']],
@@ -255,7 +259,9 @@ def extract_sightings(output):
                 'id': f'transient:{uuid4()}',
                 'count': len(output['riskfactors']),
                 'observables': [observable],
-                'observed_time': time_to_ctr_format(start_time),
+                'observed_time': {
+                    'start_time': time_to_ctr_format(start_time)
+                },
                 'description': riskfactor['description'],
                 'severity': type_mapping['severity'],
                 'source_uri': current_app.config['UI_URL'].format(
@@ -277,7 +283,9 @@ def extract_sightings(output):
                 'count': len(output['threats']),
                 'observables': [observable],
                 'description': threat['name'],
-                'observed_time': time_to_ctr_format(start_time),
+                'observed_time': {
+                    'start_time': time_to_ctr_format(start_time)
+                },
                 'severity': type_mapping['severity'],
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"threat/?tid={threat['tid']}"),
@@ -297,7 +305,9 @@ def extract_sightings(output):
                 'id': f'transient:{uuid4()}',
                 'count': len(output['feeds']),
                 'observables': [observable],
-                'observed_time': time_to_ctr_format(start_time),
+                'observed_time': {
+                    'start_time': time_to_ctr_format(start_time)
+                },
                 'description': feed['name'],
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"feed/?fid={feed['fid']}"),

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -159,7 +159,8 @@ def extract_indicators(output, unique_ids):
             if riskfactor['rfid'] not in unique_ids['riskfactors'].keys():
                 generated_id = f'transient:{uuid4()}'
                 unique_ids['riskfactors'][riskfactor['rfid']] = {
-                    'indicator_id': generated_id
+                    'indicator_id': generated_id,
+                    'sightings_id': [],
                 }
                 doc = {
                     'id': generated_id,
@@ -175,7 +176,8 @@ def extract_indicators(output, unique_ids):
             if threat['tid'] not in unique_ids['threats'].keys():
                 generated_id = f'transient:{uuid4()}'
                 unique_ids['threats'][threat['tid']] = {
-                    'indicator_id': generated_id
+                    'indicator_id': generated_id,
+                    'sightings_id': [],
                 }
                 score = output['risk']
 
@@ -205,7 +207,8 @@ def extract_indicators(output, unique_ids):
             if feed['fid'] not in unique_ids['feeds'].keys():
                 generated_id = f'transient:{uuid4()}'
                 unique_ids['feeds'][feed['fid']] = {
-                    'indicator_id': generated_id
+                    'indicator_id': generated_id,
+                    'sightings_id': [],
                 }
                 start_time = datetime.strptime(feed['stamp_linked'],
                                                '%Y-%m-%d %H:%M:%S')
@@ -226,7 +229,7 @@ def extract_indicators(output, unique_ids):
     return docs
 
 
-def extract_sightings(output):
+def extract_sightings(output, unique_ids):
     docs = []
 
     observable = {
@@ -255,8 +258,13 @@ def extract_sightings(output):
 
             start_time = datetime.strptime(output['stamp_seen'],
                                            '%Y-%m-%d %H:%M:%S')
+
+            generated_id = f'transient:{uuid4()}'
+            unique_ids['riskfactors'][riskfactor['rfid']]['sightings_id'].\
+                append(generated_id)
+
             doc = {
-                'id': f'transient:{uuid4()}',
+                'id': generated_id,
                 'count': len(output['riskfactors']),
                 'observables': [observable],
                 'observed_time': {
@@ -278,8 +286,12 @@ def extract_sightings(output):
             start_time = datetime.strptime(threat['stamp_linked'],
                                            '%Y-%m-%d %H:%M:%S')
 
+            generated_id = f'transient:{uuid4()}'
+            unique_ids['threats'][threat['tid']]['sightings_id'].\
+                append(generated_id)
+
             doc = {
-                'id': f'transient:{uuid4()}',
+                'id': generated_id,
                 'count': len(output['threats']),
                 'observables': [observable],
                 'description': threat['name'],
@@ -301,8 +313,13 @@ def extract_sightings(output):
 
             start_time = datetime.strptime(feed['stamp_linked'],
                                            '%Y-%m-%d %H:%M:%S')
+
+            generated_id = f'transient:{uuid4()}'
+            unique_ids['feeds'][feed['fid']]['sightings_id'].\
+                append(generated_id)
+
             doc = {
-                'id': f'transient:{uuid4()}',
+                'id': generated_id,
                 'count': len(output['feeds']),
                 'observables': [observable],
                 'observed_time': {
@@ -350,7 +367,7 @@ def observe_observables():
         verdicts.append(extract_verdict(output))
         judgements.append(extract_judgement(output))
         indicators += extract_indicators(output, unique_ids)
-        sightings += extract_sightings(output)
+        sightings += extract_sightings(output, unique_ids)
     relay_output = {}
 
     if judgements:

--- a/config.py
+++ b/config.py
@@ -40,6 +40,13 @@ class Config(object):
         'schema_version': CTIM_SCHEMA_VERSION,
     }
 
+    CTIM_SIGHTING_DEFAULTS = {
+        'type': 'sighting',
+        'source': 'Pulsedive',
+        'confidence': 'Medium',
+        'schema_version': CTIM_SCHEMA_VERSION,
+    }
+
     PULSEDIVE_API_THREAT_TYPES = {
       "none": {
         "disposition": 1,

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -113,6 +113,11 @@ def test_enrich_call_without_jwt_success(any_route,
         for indicator in indicators['docs']:
             assert indicator.pop('id')
 
+        sightings = data['data']['sightings']
+        assert sightings['count'] == 5
+        for sighting in sightings['docs']:
+            assert sighting.pop('id')
+
         assert data == expected_payload
     else:
         response = client.post(any_route)
@@ -168,6 +173,11 @@ def test_enrich_call_success(any_route,
         assert indicators['count'] == 5
         for indicator in indicators['docs']:
             assert indicator.pop('id')
+
+        sightings = data['data']['sightings']
+        assert sightings['count'] == 5
+        for sighting in sightings['docs']:
+            assert sighting.pop('id')
 
         assert data == expected_payload
     else:

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -161,6 +161,175 @@ EXPECTED_PAYLOAD_OBSERVE = {
           }
         }
       ]
+    },
+    "sightings": {
+      "count": 5,
+      "docs": [
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "short_description": "found in threat feeds",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/indicator/?iid=118",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "short_description": "registration recently updated",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/indicator/?iid=118",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "short_description": "JS Crypto Miner",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/threat/?tid=108",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "short_description": "Kraken Botnet",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/threat/?tid=9",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 1,
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "short_description": "BBcan177 DNSBL",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/feed/?fid=13",
+          "type": "sighting"
+        }
+      ]
     }
   }
 }

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -193,7 +193,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
           ],
           "schema_version": "1.0.16",
           "severity": "Medium",
-          "short_description": "found in threat feeds",
+          "description": "found in threat feeds",
           "source": "Pulsedive",
           "source_uri": "https://pulsedive.com/indicator/?iid=118",
           "type": "sighting"
@@ -226,7 +226,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
           ],
           "schema_version": "1.0.16",
           "severity": "Medium",
-          "short_description": "registration recently updated",
+          "description": "registration recently updated",
           "source": "Pulsedive",
           "source_uri": "https://pulsedive.com/indicator/?iid=118",
           "type": "sighting"
@@ -259,7 +259,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
           ],
           "schema_version": "1.0.16",
           "severity": "Medium",
-          "short_description": "JS Crypto Miner",
+          "description": "JS Crypto Miner",
           "source": "Pulsedive",
           "source_uri": "https://pulsedive.com/threat/?tid=108",
           "type": "sighting"
@@ -292,7 +292,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
           ],
           "schema_version": "1.0.16",
           "severity": "Medium",
-          "short_description": "Kraken Botnet",
+          "description": "Kraken Botnet",
           "source": "Pulsedive",
           "source_uri": "https://pulsedive.com/threat/?tid=9",
           "type": "sighting"
@@ -324,7 +324,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
             }
           ],
           "schema_version": "1.0.16",
-          "short_description": "BBcan177 DNSBL",
+          "description": "BBcan177 DNSBL",
           "source": "Pulsedive",
           "source_uri": "https://pulsedive.com/feed/?fid=13",
           "type": "sighting"

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -58,9 +58,9 @@ EXPECTED_PAYLOAD_OBSERVE = {
       "count": 5,
       "docs": [
         {
+          "producer": "Pulsedive",
+          "schema_version": "1.0.16",
           "short_description": "found in threat feeds",
-          "producer": "Pulsedive",
-          "schema_version": "1.0.16",
           "tlp": "white",
           "type": "indicator",
           "valid_time": {
@@ -69,9 +69,9 @@ EXPECTED_PAYLOAD_OBSERVE = {
           }
         },
         {
+          "producer": "Pulsedive",
+          "schema_version": "1.0.16",
           "short_description": "registration recently updated",
-          "producer": "Pulsedive",
-          "schema_version": "1.0.16",
           "tlp": "white",
           "type": "indicator",
           "valid_time": {
@@ -80,12 +80,14 @@ EXPECTED_PAYLOAD_OBSERVE = {
           }
         },
         {
-          "short_description": "JS Crypto Miner",
           "producer": "Pulsedive",
           "schema_version": "1.0.16",
           "severity": "Medium",
+          "short_description": "JS Crypto Miner",
           "source_uri": "https://pulsedive.com/threat/?tid=108",
-          "tags": ["abuse"],
+          "tags": [
+            "abuse"
+          ],
           "tlp": "white",
           "type": "indicator",
           "valid_time": {
@@ -93,12 +95,14 @@ EXPECTED_PAYLOAD_OBSERVE = {
           }
         },
         {
-          "short_description": "Kraken Botnet",
           "producer": "Pulsedive",
           "schema_version": "1.0.16",
           "severity": "Medium",
+          "short_description": "Kraken Botnet",
           "source_uri": "https://pulsedive.com/threat/?tid=9",
-          "tags": ["malware"],
+          "tags": [
+            "malware"
+          ],
           "tlp": "white",
           "type": "indicator",
           "valid_time": {
@@ -106,11 +110,13 @@ EXPECTED_PAYLOAD_OBSERVE = {
           }
         },
         {
-          "short_description": "BBcan177 DNSBL",
           "producer": "BBcan177",
           "schema_version": "1.0.16",
+          "short_description": "BBcan177 DNSBL",
           "source_uri": "https://pulsedive.com/feed/?fid=13",
-          "tags": ["general"],
+          "tags": [
+            "general"
+          ],
           "tlp": "white",
           "type": "indicator",
           "valid_time": {
@@ -144,6 +150,175 @@ EXPECTED_PAYLOAD_OBSERVE = {
         }
       ]
     },
+    "sightings": {
+      "count": 5,
+      "docs": [
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "description": "found in threat feeds",
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/indicator/?iid=118",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "description": "registration recently updated",
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/indicator/?iid=118",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "description": "JS Crypto Miner",
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2018-08-06T03:44:07Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/threat/?tid=108",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 2,
+          "description": "Kraken Botnet",
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2019-01-01T04:01:30Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "severity": "Medium",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/threat/?tid=9",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 1,
+          "description": "BBcan177 DNSBL",
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-02-10T07:41:05Z"
+          },
+          "relations": [
+            {
+              "origin": "Pulsedive Enrichment Module",
+              "related": {
+                "type": "ip",
+                "value": "185.53.179.29"
+              },
+              "relation": "Resolved_To",
+              "source": {
+                "type": "domain",
+                "value": "parkingcrew.net"
+              }
+            }
+          ],
+          "schema_version": "1.0.16",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/feed/?fid=13",
+          "type": "sighting"
+        }
+      ]
+    },
     "verdicts": {
       "count": 1,
       "docs": [
@@ -159,175 +334,6 @@ EXPECTED_PAYLOAD_OBSERVE = {
             "end_time": "2020-06-30T20:47:36Z",
             "start_time": "2020-03-31T14:47:36Z"
           }
-        }
-      ]
-    },
-    "sightings": {
-      "count": 5,
-      "docs": [
-        {
-          "confidence": "Medium",
-          "count": 2,
-          "observables": [
-            {
-              "type": "domain",
-              "value": "parkingcrew.net"
-            }
-          ],
-          "observed_time": {
-            "start_time": "2020-03-31T14:47:36Z"
-          },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
-          "schema_version": "1.0.16",
-          "severity": "Medium",
-          "description": "found in threat feeds",
-          "source": "Pulsedive",
-          "source_uri": "https://pulsedive.com/indicator/?iid=118",
-          "type": "sighting"
-        },
-        {
-          "confidence": "Medium",
-          "count": 2,
-          "observables": [
-            {
-              "type": "domain",
-              "value": "parkingcrew.net"
-            }
-          ],
-          "observed_time": {
-            "start_time": "2020-03-31T14:47:36Z"
-          },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
-          "schema_version": "1.0.16",
-          "severity": "Medium",
-          "description": "registration recently updated",
-          "source": "Pulsedive",
-          "source_uri": "https://pulsedive.com/indicator/?iid=118",
-          "type": "sighting"
-        },
-        {
-          "confidence": "Medium",
-          "count": 2,
-          "observables": [
-            {
-              "type": "domain",
-              "value": "parkingcrew.net"
-            }
-          ],
-          "observed_time": {
-            "start_time": "2020-03-31T14:47:36Z"
-          },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
-          "schema_version": "1.0.16",
-          "severity": "Medium",
-          "description": "JS Crypto Miner",
-          "source": "Pulsedive",
-          "source_uri": "https://pulsedive.com/threat/?tid=108",
-          "type": "sighting"
-        },
-        {
-          "confidence": "Medium",
-          "count": 2,
-          "observables": [
-            {
-              "type": "domain",
-              "value": "parkingcrew.net"
-            }
-          ],
-          "observed_time": {
-            "start_time": "2020-03-31T14:47:36Z"
-          },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
-          "schema_version": "1.0.16",
-          "severity": "Medium",
-          "description": "Kraken Botnet",
-          "source": "Pulsedive",
-          "source_uri": "https://pulsedive.com/threat/?tid=9",
-          "type": "sighting"
-        },
-        {
-          "confidence": "Medium",
-          "count": 1,
-          "observables": [
-            {
-              "type": "domain",
-              "value": "parkingcrew.net"
-            }
-          ],
-          "observed_time": {
-            "start_time": "2020-03-31T14:47:36Z"
-          },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
-          "schema_version": "1.0.16",
-          "description": "BBcan177 DNSBL",
-          "source": "Pulsedive",
-          "source_uri": "https://pulsedive.com/feed/?fid=13",
-          "type": "sighting"
         }
       ]
     }


### PR DESCRIPTION

![Pulsedirve_Response_Mapping](https://user-images.githubusercontent.com/48979187/78547246-74543000-7807-11ea-9fda-dbde14b81480.JPG)

the Observable 1 and Observable 2 is the response from Pulsedive for 2 observables, each riskfactor, threat, and feed becomes an indicator in CTIM

then each sighting points to the indicator and a sighting from two different observables can point to the same indicator object

here are two examples that return the same threats and feeds:
https://pulsedive.com/api/?pretty=true&iid=3191141
https://pulsedive.com/api/?pretty=true&iid=3191117

The end goal in Threat Response if someone were to search for both of those domains at the same time there would be one indicator for the feed "BBcan177 DNSBL" and both domains would have sightings with a relationship pointing to that one feed indicator