### PR TITLE
Pulsedive unexpected response bug fix

### DIFF
--- a/api/enrich.py
+++ b/api/enrich.py
@@ -230,19 +230,19 @@ def get_relationship(source_ref, target_ref, relationship_type):
 
 def get_related_ips(observable, ips):
     relations = []
-    if ips:
-        if isinstance(ips, str):
-            ips = [ips]
 
-        for ip in ips:
-            relations.append(
-                {
-                            'origin': 'Pulsedive Enrichment Module',
-                            'related': {'type': 'ip', 'value': ip},
-                            'relation': 'Resolved_To',
-                            'source': observable,
-                }
-            )
+    if isinstance(ips, str):
+        ips = [ips]
+
+    for ip in ips:
+        relations.append(
+            {
+                'origin': 'Pulsedive Enrichment Module',
+                'related': {'type': 'ip', 'value': ip},
+                'relation': 'Resolved_To',
+                'source': observable,
+            }
+        )
     return relations
 
 
@@ -264,7 +264,7 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
 
     related_ips = get_related_ips(
         observable,
-        output['properties'].get('dns', {}).get('A')
+        output['properties'].get('dns', {}).get('A', [])
     )
 
     if output.get('riskfactors'):

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -228,6 +228,24 @@ def get_relationship(source_ref, target_ref, relationship_type):
             }
 
 
+def get_related_ips(observable, ips):
+    relations = []
+    if ips:
+        if type(ips) != list:
+            ips = [ips]
+
+        for ip in ips:
+            relations.append(
+                {
+                            'origin': 'Pulsedive Enrichment Module',
+                            'related': {'type': 'ip', 'value': ip},
+                            'relation': 'Resolved_To',
+                            'source': observable,
+                }
+            )
+    return relations
+
+
 def extract_sightings(output, unique_indicator_ids, sightings_relationship):
     docs = []
 
@@ -244,13 +262,10 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
     type_mapping = \
         current_app.config["PULSEDIVE_API_THREAT_TYPES"][score]
 
-    related = output['properties'].get('dns', {}).get('A')
-    relations = {
-                'origin': 'Pulsedive Enrichment Module',
-                'related': {'type': 'ip', 'value': related},
-                'relation': 'Resolved_To',
-                'source': observable,
-            }
+    related_ips = get_related_ips(
+        observable,
+        output['properties'].get('dns', {}).get('A')
+    )
 
     if output.get('riskfactors'):
         for riskfactor in output['riskfactors']:
@@ -273,12 +288,12 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
                 },
                 'description': riskfactor['description'],
                 'severity': type_mapping['severity'],
+                'relations': related_ips,
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"indicator/?iid={output['iid']}"),
                 **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
-            if related:
-                doc['relations'] = [relations]
+
             docs.append(doc)
 
     if output.get('threats'):
@@ -303,12 +318,11 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
                     'start_time': time_to_ctr_format(start_time)
                 },
                 'severity': type_mapping['severity'],
+                'relations': related_ips,
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"threat/?tid={threat['tid']}"),
                 **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
-            if related:
-                doc['relations'] = [relations]
             docs.append(doc)
 
     if output.get('feeds'):
@@ -333,12 +347,11 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
                     'start_time': time_to_ctr_format(start_time)
                 },
                 'description': feed['name'],
+                'relations': related_ips,
                 'source_uri': current_app.config['UI_URL'].format(
                     query=f"feed/?fid={feed['fid']}"),
                 **current_app.config['CTIM_SIGHTING_DEFAULTS']
             }
-            if related:
-                doc['relations'] = [relations]
             docs.append(doc)
 
     return docs

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -231,7 +231,7 @@ def get_relationship(source_ref, target_ref, relationship_type):
 def get_related_ips(observable, ips):
     relations = []
     if ips:
-        if not isinstance(ips, list):
+        if isinstance(ips, str):
             ips = [ips]
 
         for ip in ips:

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -231,7 +231,7 @@ def get_relationship(source_ref, target_ref, relationship_type):
 def get_related_ips(observable, ips):
     relations = []
     if ips:
-        if type(ips) != list:
+        if not isinstance(ips, list):
             ips = [ips]
 
         for ip in ips:

--- a/api/errors.py
+++ b/api/errors.py
@@ -39,4 +39,7 @@ class StandardHttpError(TRFormattedError):
 
 class InvalidInputError(TRFormattedError):
     def __init__(self, message):
-        super().__init__("invalid argument", message)
+        super().__init__(
+            "invalid argument",
+            f'Invalid JSON payload received. {message}'
+        )

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -143,7 +143,7 @@ def test_enrich_call_without_jwt_but_invalid_json_failure(route,
 
 @fixture(scope='module')
 def invalid_json():
-    return [{'type': 'unknown', 'value': ''}]
+    return [{'type': 'unknown', 'value': 'https://google.com'}]
 
 
 def test_enrich_call_with_valid_jwt_but_invalid_json_failure(route,

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -22,23 +22,25 @@ EXPECTED_PAYLOAD_INVALID_INPUT = {
     "errors": [
       {
         "code": "invalid argument",
-        "message": "Invalid JSON payload received."
-                   " {0: {'value': ['Field may not be blank.'],"
-                   " 'type': [\"Must be one of: 'amp_computer_guid',"
-                   " 'certificate_common_name', 'certificate_issuer',"
-                   " 'certificate_serial', 'cisco_mid', 'device',"
-                   " 'domain', 'email', 'email_messageid',"
-                   " 'email_subject', 'file_name', 'file_path',"
-                   " 'hostname', 'imei', 'imsi', 'ip',"
-                   " 'ipv6', 'mac_address', 'md5', 'mutex', 'ngfw_id',"
-                   " 'ngfw_name', 'odns_identity', 'odns_identity_label',"
-                   " 'orbital_node_id', 'pki_serial', 'process_name',"
-                   " 'registry_key', 'registry_name', 'registry_path', "
-                   "'sha1', 'sha256', 'url', 'user', 'user_agent'.\"]}}",
+        "message": "Invalid JSON payload received. {0: {'type': "
+                   "[\"Must be one of: 'amp_computer_guid', "
+                   "'certificate_common_name', "
+                   "'certificate_issuer', 'certificate_serial',"
+                   " 'cisco_mid', 'device', 'domain', 'email', "
+                   "'email_messageid', 'email_subject', 'file_name',"
+                   " 'file_path', 'hostname', 'imei', 'imsi', 'ip', "
+                   "'ipv6', 'mac_address', 'md5', 'mutex', 'ngfw_id',"
+                   " 'ngfw_name', 'odns_identity', "
+                   "'odns_identity_label', 'orbital_node_id',"
+                   " 'pki_serial', 'process_name', 'registry_key', "
+                   "'registry_name', 'registry_path', 'sha1',"
+                   " 'sha256', 'url', 'user', 'user_agent'.\"], "
+                   "'value': ['Field may not be blank.']}}",
         "type": "fatal"
       }
     ]
 }
+
 
 EXPECTED_PAYLOAD_OBSERVE = {
   "data": {

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -19,26 +19,23 @@ EXPECTED_PAYLOAD_REQUEST_TIMOUT = {
 }
 
 EXPECTED_PAYLOAD_INVALID_INPUT = {
-    "errors": [
-      {
-        "code": "invalid argument",
-        "message": "Invalid JSON payload received. {0: {'type': "
-                   "[\"Must be one of: 'amp_computer_guid', "
-                   "'certificate_common_name', "
-                   "'certificate_issuer', 'certificate_serial',"
-                   " 'cisco_mid', 'device', 'domain', 'email', "
-                   "'email_messageid', 'email_subject', 'file_name',"
-                   " 'file_path', 'hostname', 'imei', 'imsi', 'ip', "
-                   "'ipv6', 'mac_address', 'md5', 'mutex', 'ngfw_id',"
-                   " 'ngfw_name', 'odns_identity', "
-                   "'odns_identity_label', 'orbital_node_id',"
-                   " 'pki_serial', 'process_name', 'registry_key', "
-                   "'registry_name', 'registry_path', 'sha1',"
-                   " 'sha256', 'url', 'user', 'user_agent'.\"], "
-                   "'value': ['Field may not be blank.']}}",
-        "type": "fatal"
-      }
-    ]
+  'errors': [
+    {'code': 'invalid argument',
+             'message': 'Invalid JSON payload received. {0: {\'type\': ["Must '
+                        "be one of: 'amp_computer_guid', "
+                        "'certificate_common_name', 'certificate_issuer', "
+                        "'certificate_serial', 'cisco_mid', 'device', "
+                        "'domain', 'email', 'email_messageid', "
+                        "'email_subject', 'file_name', 'file_path', "
+                        "'hostname', 'imei', 'imsi', 'ip', 'ipv6', "
+                        "'mac_address', 'md5', 'mutex', 'ngfw_id', "
+                        "'ngfw_name', 'odns_identity', 'odns_identity_label', "
+                        "'orbital_node_id', 'pki_serial', 'process_name', "
+                        "'registry_key', 'registry_name', 'registry_path', "
+                        "'sha1', 'sha256', 'url', 'user', "
+                        '\'user_agent\'."]}}',
+             'type': 'fatal'}
+  ]
 }
 
 

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -20,37 +20,25 @@ EXPECTED_PAYLOAD_REQUEST_TIMOUT = {
 
 EXPECTED_PAYLOAD_INVALID_INPUT = {
     "errors": [
-        {
-            "code": "invalid argument",
-            "message": {
-                "0": {
-                    "type": [
-                        "Must be one of: 'amp_computer_guid', "
-                        "'certificate_common_name', "
-                        "'certificate_issuer', "
-                        "'certificate_serial', 'cisco_mid', "
-                        "'device', 'domain', 'email', "
-                        "'email_messageid', 'email_subject', "
-                        "'file_name', 'file_path', 'hostname', "
-                        "'imei', 'imsi', 'ip', 'ipv6', "
-                        "'mac_address', 'md5', 'mutex', "
-                        "'ngfw_id', 'ngfw_name', "
-                        "'odns_identity', "
-                        "'odns_identity_label', "
-                        "'orbital_node_id', 'pki_serial', "
-                        "'process_name', 'registry_key', "
-                        "'registry_name', 'registry_path', "
-                        "'sha1', 'sha256', 'url', 'user', "
-                        "'user_agent'."
-                    ],
-                    "value": ["Field may not be blank."],
-                }
-            },
-            "type": "fatal",
-        }
+      {
+        "code": "invalid argument",
+        "message": "Invalid JSON payload received."
+                   " {0: {'value': ['Field may not be blank.'],"
+                   " 'type': [\"Must be one of: 'amp_computer_guid',"
+                   " 'certificate_common_name', 'certificate_issuer',"
+                   " 'certificate_serial', 'cisco_mid', 'device',"
+                   " 'domain', 'email', 'email_messageid',"
+                   " 'email_subject', 'file_name', 'file_path',"
+                   " 'hostname', 'imei', 'imsi', 'ip',"
+                   " 'ipv6', 'mac_address', 'md5', 'mutex', 'ngfw_id',"
+                   " 'ngfw_name', 'odns_identity', 'odns_identity_label',"
+                   " 'orbital_node_id', 'pki_serial', 'process_name',"
+                   " 'registry_key', 'registry_name', 'registry_path', "
+                   "'sha1', 'sha256', 'url', 'user', 'user_agent'.\"]}}",
+        "type": "fatal"
+      }
     ]
 }
-
 
 EXPECTED_PAYLOAD_OBSERVE = {
   "data": {


### PR DESCRIPTION
An error occurred when a list was received instead of a string. ![Screenshot 2020-04-08 at 10 04 18](https://user-images.githubusercontent.com/48979187/78754592-6b3a9e80-7980-11ea-9845-f7a7e827d46c.png)
![Screenshot 2020-04-08 at 09 55 12](https://user-images.githubusercontent.com/48979187/78754244-d9329600-797f-11ea-8552-d775f7e25480.png)
And when POST request was sent to observe/observable with empty value, result was : "message": "{:error \"{:errors [{:message (not (instance? java.lang.String a-clojure.lang.PersistentArrayMap))}]}\"} [:invalid-server-response]". 