### PR TITLE
Update Pulsedive integration according to Michael's notes

### DIFF
--- a/api/enrich.py
+++ b/api/enrich.py
@@ -278,12 +278,12 @@ def get_related_entities(observable):
                 relations.append(
                     {
                         'origin': 'Pulsedive Enrichment Module',
-                        'related': {
+                        'related': observable,
+                        'relation': 'Resolved_To',
+                        'source':  {
                             'type': entity['type'],
                             'value': entity['indicator']
                         },
-                        'relation': 'Resolved_To',
-                        'source': observable,
                     }
                 )
     return relations

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -423,7 +423,9 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
             },
             'description': 'Active DNS',
             'relations': relations,
-            **current_app.config['CTIM_SIGHTING_DEFAULTS']
+            **current_app.config['CTIM_SIGHTING_DEFAULTS'],
+            'source_uri': current_app.config['UI_URL'].format(
+                query=f"indicator/?iid={output['iid']}"),
         }
 
         if len(docs) >= current_app.config['CTR_ENTITIES_LIMIT']:

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -275,12 +275,20 @@ def get_related_entities(observable):
         for entity in entities:
             if (entity['type'], observable['type']) in valid_pairs\
                     and entity['risk'] != 'retired':
+                source, related = None, None
+                if observable['type'] == 'domain':
+                    source = observable
+                else:
+                    related = observable
                 relations.append(
                     {
                         'origin': 'Pulsedive Enrichment Module',
-                        'related': observable,
+                        'related': related or {
+                            'type': entity['type'],
+                            'value': entity['indicator']
+                        },
                         'relation': 'Resolved_To',
-                        'source':  {
+                        'source': source or {
                             'type': entity['type'],
                             'value': entity['indicator']
                         },

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -201,7 +201,7 @@ def extract_indicators(output, unique_ids):
 
                 doc = {
                     'id': generated_id,
-                    'short_description': threat['name'],
+                    'short_description': f"Threat: {threat['name']}",
                     'producer': 'Pulsedive',
                     'valid_time': {
                         'start_time': time_to_ctr_format(start_time)
@@ -349,7 +349,7 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
                 'id': generated_id,
                 'count': 1,
                 'observables': [observable],
-                'description': threat['name'],
+                'description': f"Threat: {threat['name']}",
                 'observed_time': {
                     'start_time': time_to_ctr_format(start_time)
                 },

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -262,16 +262,8 @@ def get_relationship(source_ref, target_ref, relationship_type):
             'relationship_type': relationship_type,
             }
 
-def build_relations(source, related):
-    return {
-                        'origin': 'Pulsedive Enrichment Module',
-                        'related': related,
-                        'relation': 'Resolved_To',
-                        'source': source,
-                    }
 
-
-def get_related_entities(observable):  
+def get_related_entities(observable):
     output = get_pulsedive_output([observable['value']], links=True)
     relations = []
     if not output:
@@ -288,17 +280,21 @@ def get_related_entities(observable):
             if (entity['type'], observable['type']) in valid_pairs\
                     and entity['risk'] != 'retired':
                 if observable['type'] == 'domain':
-                    relations.append(build_relations(source=observable,
-                                    related={
-                            'type': entity['type'],
-                            'value': entity['indicator']
-                        }))
+                    relations.append(
+                        {**current_app.config['OBSERVED_RELATIONS_DEFAULTS'],
+                         "source": observable,
+                         "related": {
+                                'type': entity['type'],
+                                'value': entity['indicator']
+                                }})
                 else:
-                    relations.append(build_relations(source={
-                                        'type': entity['type'],
-                                        'value': entity['indicator']
-                                    },
-                                    related=observable))
+                    relations.append(
+                        {**current_app.config['OBSERVED_RELATIONS_DEFAULTS'],
+                         "source": {
+                                'type': entity['type'],
+                                'value': entity['indicator']
+                                },
+                         "related": observable})
     return relations
 
 

--- a/api/enrich.py
+++ b/api/enrich.py
@@ -405,10 +405,8 @@ def extract_sightings(output, unique_indicator_ids, sightings_relationship):
         start_time = datetime.strptime(output['stamp_seen'],
                                        '%Y-%m-%d %H:%M:%S')
 
-        generated_id = f'transient:sighting-{uuid4()}'
-
         doc = {
-            'id': generated_id,
+            'id': f'transient:sighting-{uuid4()}',
             'count': 1,
             'observables': [observable],
             'observed_time': {

--- a/api/health.py
+++ b/api/health.py
@@ -1,20 +1,20 @@
 import requests
-from flask import Blueprint
+from flask import Blueprint, current_app
 
 from api.errors import (UnexpectedPulsediveError,
                         StandardHttpError)
-from api.utils import url_for, jsonify_data, get_jwt
+from api.utils import jsonify_data, get_jwt
 
 health_api = Blueprint('health', __name__)
 
 
 @health_api.route('/health', methods=['POST'])
 def health():
-    key = get_jwt().get('key')
+    params = {'iid': 2, 'key': get_jwt().get('key')}
 
-    url = url_for("iid=2", key)
+    url = current_app.config["API_URL"]
 
-    response = requests.get(url)
+    response = requests.get(url, params)
 
     error = response.json().get('error')
     if error not in (None, "Indicator not found."):

--- a/api/utils.py
+++ b/api/utils.py
@@ -5,13 +5,6 @@ from flask import request, current_app, jsonify
 from api.errors import JwtError, InvalidInputError
 
 
-def url_for(query, key):
-    return current_app.config["API_URL"].format(
-        query=query,
-        key=key
-    )
-
-
 def get_jwt():
     try:
         scheme, token = request.headers['Authorization'].split()

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ class Config(object):
 
     SECRET_KEY = os.environ.get('SECRET_KEY', '')
 
-    API_URL = 'https://pulsedive.com/api/info.php?{query}&key={key}'
+    API_URL = 'https://pulsedive.com/api/info.php'
 
     UI_URL = "https://pulsedive.com/{query}"
 

--- a/config.py
+++ b/config.py
@@ -70,6 +70,11 @@ class Config(object):
         'schema_version': CTIM_SCHEMA_VERSION,
     }
 
+    OBSERVED_RELATIONS_DEFAULTS = {
+        'origin': 'Pulsedive Enrichment Module',
+        'relation': 'Resolved_To',
+    }
+
     PULSEDIVE_API_THREAT_TYPES = {
       "none": {
         "disposition": 1,

--- a/tests/functional/tests/test_relationships.py
+++ b/tests/functional/tests/test_relationships.py
@@ -30,8 +30,9 @@ def test_positive_relationship_detail(module_headers):
     sightings = entities['sightings']
     indicators = entities['indicators']
 
-    # sighting has one relationship with indicator
-    assert sightings['count'] == indicators['count']
+    # sighting and indicator not less then relationships
+    assert sightings['count']\
+        and indicators['count'] >= relationships['count']
 
     sightings_id = [s['id'] for s in sightings['docs']]
     indicators_id = [i['id'] for i in indicators['docs']]
@@ -88,9 +89,13 @@ def test_positive_relationship_several_observables(module_headers):
     # Each sighting exists in relationships
     sighting_indicator = {r['source_ref']: r['target_ref']
                           for r in relationships['docs']}
-    for sighting in sightings['docs']:
-        assert sighting['id'] in sighting_indicator
+    if sightings['count'] <= indicators['count']:
+        for sighting in sightings['docs']:
+            assert sighting['id'] in sighting_indicator
 
     # Each indicator exists in relationships
-    for indicator in indicators['docs']:
-        assert indicator['id'] in {v: k for k, v in sighting_indicator.items()}
+    if indicators['count'] <= sightings['count']:
+        for indicator in indicators['docs']:
+            assert indicator['id'] in {
+                v: k for k, v in sighting_indicator.items()
+            }

--- a/tests/functional/tests/test_sightings.py
+++ b/tests/functional/tests/test_sightings.py
@@ -38,16 +38,16 @@ def test_positive_sighting_domain(module_headers):
 
         assert len(sighting['observables']) == 1
         assert sighting['observables'][0] == observable
-
-        assert len(sighting['relations']) == 2
-        for relation in sighting['relations']:
-            assert relation['origin'] == 'Pulsedive Enrichment Module'
-            assert relation['relation'] == 'Resolved_To'
-            assert relation['source'] == {'value': 'brehmen.com',
-                                          'type': 'domain'}
-            assert relation['related']['value'] in ('81.169.145.159',
-                                                    '2a01:238:20a:202:1159::')
-            assert relation['related']['type'] in ('ip', 'ipv6')
+        if 'relations' in sighting:
+            assert len(sighting['relations']) == 1
+            for relation in sighting['relations']:
+                assert relation['origin'] == 'Pulsedive Enrichment Module'
+                assert relation['relation'] == 'Resolved_To'
+                assert relation['source'] == {'value': 'brehmen.com',
+                                              'type': 'domain'}
+                assert relation['related']['value'] in ('81.169.145.159',
+                                                        '2a01:238:20a:202:1159::')
+                assert relation['related']['type'] in ('ip', 'ipv6')
 
 
 def test_positive_sighting_ip(module_headers):

--- a/tests/functional/tests/test_sightings.py
+++ b/tests/functional/tests/test_sightings.py
@@ -24,7 +24,7 @@ def test_positive_sighting_domain(module_headers):
     )
     sightings = get_observables(
         response['data'], 'Pulsedive')['data']['sightings']
-    assert sightings['count'] == 5
+    assert sightings['count'] == 6
 
     for sighting in sightings['docs']:
         assert sighting['count'] == 1
@@ -72,7 +72,7 @@ def test_positive_sighting_ip(module_headers):
     )
     sightings = get_observables(
         response['data'], 'Pulsedive')['data']['sightings']
-    assert sightings['count'] == 10
+    assert sightings['count'] == 13
 
     for sighting in sightings['docs']:
         assert sighting['count'] == 1

--- a/tests/functional/tests/test_sightings.py
+++ b/tests/functional/tests/test_sightings.py
@@ -38,7 +38,7 @@ def test_positive_sighting_domain(module_headers):
 
         assert len(sighting['observables']) == 1
         assert sighting['observables'][0] == observable
-        if sighting.get('relations'):
+        if 'relations' in sighting:
             assert len(sighting['relations']) == 1
             for relation in sighting['relations']:
                 assert relation['origin'] == 'Pulsedive Enrichment Module'

--- a/tests/functional/tests/test_sightings.py
+++ b/tests/functional/tests/test_sightings.py
@@ -38,15 +38,15 @@ def test_positive_sighting_domain(module_headers):
 
         assert len(sighting['observables']) == 1
         assert sighting['observables'][0] == observable
-        if 'relations' in sighting:
+        if sighting.get('relations'):
             assert len(sighting['relations']) == 1
             for relation in sighting['relations']:
                 assert relation['origin'] == 'Pulsedive Enrichment Module'
                 assert relation['relation'] == 'Resolved_To'
                 assert relation['source'] == {'value': 'brehmen.com',
                                               'type': 'domain'}
-                assert relation['related']['value'] in ('81.169.145.159',
-                                                        '2a01:238:20a:202:1159::')
+                assert relation['related']['value'] in \
+                    ('81.169.145.159', '2a01:238:20a:202:1159::')
                 assert relation['related']['type'] in ('ip', 'ipv6')
 
 

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -178,7 +178,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
       ]
     },
     "sightings": {
-      "count": 5,
+      "count": 6,
       "docs": [
         {
           "confidence": "Medium",
@@ -272,6 +272,44 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "schema_version": "1.0.16",
           "source": "Pulsedive",
           "source_uri": "https://pulsedive.com/feed/?fid=13",
+          "type": "sighting"
+        },
+        {
+          "confidence": "Medium",
+          "count": 1,
+          "description": "Active DNS",
+          "observables": [
+            {
+              "type": "domain",
+              "value": "parkingcrew.net"
+            }
+          ],
+          "observed_time": {
+            "start_time": "2020-03-31T14:47:36Z"
+          },
+          "relations": {
+            "Active DNS": [
+              {
+                "iid": 3,
+                "indicator": "187.191.98.202",
+                "risk": "low",
+                "stamp_linked": "2019-06-22 10:46:47",
+                "summary": {
+                  "properties": {
+                    "geo": {
+                      "country": "Brazil",
+                      "countrycode": "BR",
+                      "org": "Mandic S.A."
+                    }
+                  }
+                },
+                "type": "ip"
+              }
+            ]
+          },
+          "schema_version": "1.0.16",
+          "source": "Pulsedive",
+          "source_uri": "https://pulsedive.com/indicator/?iid=118",
           "type": "sighting"
         }
       ]
@@ -563,6 +601,28 @@ EXPECTED_PAYLOAD_REFER = {
       "id": "ref-pulsedive-detail-domain-parkingcrew.net",
       "title": "Browse domain",
       "url": "https://pulsedive.com/indicator/?iid=118"
+    }
+  ]
+}
+
+PULSEDIVE_ACTIVE_DNS_RESPONCE = {
+  "Active DNS":
+  [
+    {
+      "iid": 3,
+      "indicator": "187.191.98.202",
+      "type": "ip",
+      "risk": "low",
+      "stamp_linked": "2019-06-22 10:46:47",
+      "summary": {
+        "properties": {
+          "geo": {
+            "country": "Brazil",
+            "org": "Mandic S.A.",
+            "countrycode": "BR"
+          }
+        }
+      }
     }
   ]
 }

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -72,7 +72,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "producer": "Pulsedive",
           "schema_version": "1.0.16",
           "severity": "Medium",
-          "short_description": "Kraken Botnet",
+          "short_description": "Threat: Kraken Botnet",
           "source_uri": "https://pulsedive.com/threat/?tid=9",
           "tags": [
             "malware"
@@ -89,7 +89,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "source": "Pulsedive",
           "schema_version": "1.0.16",
           "severity": "Medium",
-          "short_description": "JS Crypto Miner",
+          "short_description": "Threat: JS Crypto Miner",
           "source_uri": "https://pulsedive.com/threat/?tid=108",
           "tags": [
             "abuse"
@@ -249,7 +249,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
         {
           "confidence": "Medium",
           "count": 1,
-          "description": "Kraken Botnet",
+          "description": "Threat: Kraken Botnet",
           "observables": [
             {
               "type": "domain",
@@ -282,7 +282,7 @@ EXPECTED_PAYLOAD_OBSERVE = {
         {
           "confidence": "Medium",
           "count": 1,
-          "description": "JS Crypto Miner",
+          "description": "Threat: JS Crypto Miner",
           "observables": [
             {
               "type": "domain",

--- a/tests/unit/payloads_for_tests.py
+++ b/tests/unit/payloads_for_tests.py
@@ -193,20 +193,6 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "observed_time": {
             "start_time": "2020-03-31T14:47:36Z"
           },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
           "schema_version": "1.0.16",
           "severity": "Medium",
           "source": "Pulsedive",
@@ -226,20 +212,6 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "observed_time": {
             "start_time": "2020-03-31T14:47:36Z"
           },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
           "schema_version": "1.0.16",
           "severity": "Medium",
           "source": "Pulsedive",
@@ -259,20 +231,6 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "observed_time": {
             "start_time": "2019-01-01T04:01:30Z"
           },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
           "schema_version": "1.0.16",
           "severity": "Medium",
           "source": "Pulsedive",
@@ -292,20 +250,6 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "observed_time": {
             "start_time": "2018-08-06T03:44:07Z"
           },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
           "schema_version": "1.0.16",
           "severity": "Medium",
           "source": "Pulsedive",
@@ -325,20 +269,6 @@ EXPECTED_PAYLOAD_OBSERVE = {
           "observed_time": {
             "start_time": "2020-02-10T07:41:05Z"
           },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
           "schema_version": "1.0.16",
           "source": "Pulsedive",
           "source_uri": "https://pulsedive.com/feed/?fid=13",
@@ -571,20 +501,6 @@ EXPECTED_PAYLOAD_OBSERVE_WITH_LIMIT = {
           "observed_time": {
             "start_time": "2020-03-31T14:47:36Z"
           },
-          "relations": [
-            {
-              "origin": "Pulsedive Enrichment Module",
-              "related": {
-                "type": "ip",
-                "value": "185.53.179.29"
-              },
-              "relation": "Resolved_To",
-              "source": {
-                "type": "domain",
-                "value": "parkingcrew.net"
-              }
-            }
-          ],
           "schema_version": "1.0.16",
           "severity": "Medium",
           "source": "Pulsedive",


### PR DESCRIPTION
Let's tweak the observed relations so that instead of having the observed relation from properties.dns show up in all of the Sightings we have 1 Sighting for all of the Active DNS data
Name the Sighting "Active DNS"

- For Domains only do relations for IP and IPv6 as Domain -> `Resolved_To ->
- For IPs only do relations for Domain as Domain ->Resolved_To` ->
- For everything from the "Active DNS" only make relationshpis for things that have e stamp_linked date within the last 90 days